### PR TITLE
[bugfix] Avoid replacing substrings of longer path

### DIFF
--- a/replace.coffee
+++ b/replace.coffee
@@ -15,22 +15,13 @@ module.exports = (options) ->
     throw new Error 'options.base has to be a string of an absolute path'
   unless options.manifest?
     throw new Error 'options.manifest is required'
-
-  sortFunc = (a, b) ->
-    if a.fullpath.length == b.fullpath.length
-      0
-    else if a.fullpath.length > b.fullpath.length
-      -1
-    else
-      1
-
   through.obj (file, enc, callback) ->
     outfile = file.clone()
     contents = String outfile.contents
     paths = []
     for fullpath, wanted of options.manifest
       paths.push { fullpath: fullpath, wanted: wanted }
-    paths = paths.sort sortFunc
+    paths.sort (a, b) -> b.fullpath.length - a.fullpath.length
     for pathObj in paths
       fullpath = pathObj.fullpath
       wanted = pathObj.wanted


### PR DESCRIPTION
Orders the paths that are to be replaced descending by length. This
addresses a bug where a shorter path could be injected into a longer
path, if the shorter path happened to be a substring of the longer path.

Example of manifest file:

    {
      "fonts/my-font.woff": "fonts/my-font-4275e59f78.woff",
      "fonts/my-font.woff2": "fonts/my-font-dc33444634.woff2"
    }

If `fonts/my-font.woff` is replaced first, it will give an unintended
match when `fonts/my-font.woff2` is encountered in a file. It will then
inject the hash of `fonts/my-font.woff`, which will prevent a correct
match when later replacing `fonts/my-font.woff2`.

Sorting the strings that should be replaced on string length, in
descending order, ensures that a string can never be a substring of any
other string, not already processed.